### PR TITLE
New regex for password, and pass through arguments when redirecting

### DIFF
--- a/pydentity.py
+++ b/pydentity.py
@@ -33,10 +33,12 @@ CONF = {
 @app.route("/")
 def home():
     if request.environ.get('REMOTE_USER'):
-        return redirect(url_for("user", username=request.environ.get('REMOTE_USER')))
+        url = url_for("user", username=request.environ.get('REMOTE_USER'))
+        if "return_to" in request.args:
+            url += "?return_to=%s" % request.args.get("return_to")
     else:
-        return redirect(url_for("list_users"))
-
+        url = url_for("list_users")
+    return redirect(url)
 
 @app.route("/list_users")
 def list_users():

--- a/pydentity.py
+++ b/pydentity.py
@@ -24,7 +24,7 @@ CONF = {
     # Whether to require http basic auth upstream (for example with apache)
     "REQUIRE_REMOTE_USER": True,
     # New password pattern regexp check. Note that this regexp must be compliant to both Python regexp syntax and HTML 5 form pattern syntax
-    "PASSWORD_PATTERN": "(?=.*\d)(?=.*[a-z])(?=.*[A-Z!@#$%^&*-]).{8,}",
+    "PASSWORD_PATTERN": "(?=.*\d)(?=.*[a-z])(?=.*[A-Z\!\@\#\$\%\^\&\*\-]).{8,}",
     # Clear text that explain to user the password requirements
     "PASSWORD_PATTERN_HELP" : "Upper and lower case, numeric. At least 8 char",
 }

--- a/pydentity.py
+++ b/pydentity.py
@@ -24,7 +24,7 @@ CONF = {
     # Whether to require http basic auth upstream (for example with apache)
     "REQUIRE_REMOTE_USER": True,
     # New password pattern regexp check. Note that this regexp must be compliant to both Python regexp syntax and HTML 5 form pattern syntax
-    "PASSWORD_PATTERN": "(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+    "PASSWORD_PATTERN": "(?=.*\d)(?=.*[a-z])(?=.*[A-Z!@#$%^&*-]).{8,}",
     # Clear text that explain to user the password requirements
     "PASSWORD_PATTERN_HELP" : "Upper and lower case, numeric. At least 8 char",
 }

--- a/templates/user.html
+++ b/templates/user.html
@@ -22,7 +22,7 @@
               {% endif %}
               <label class="col-md-6 control-label" for="new_password">New password</label>
               <div class="col-md-6">
-                <input id="new_password" name="new_password" type="password" required pattern="{{ password_pattern }}" onchange="form.repeat_password.pattern = this.value;" title="Upper and lower case, numeric. At least 8 char" placeholder="{{ password_pattern_help }}" class="form-control input-md" >
+                <input id="new_password" name="new_password" type="password" required pattern="{{ password_pattern }}" onchange="form.repeat_password.pattern = (this.value+'').replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');" title="Lower case, numeric, and at least one upper case or special character in !, @, #, $, %, ^, & *, -. At least 8 char." placeholder="{{ password_pattern_help }}" class="form-control input-md" >
               </div>
               <label class="col-md-6 control-label" for="repeat_password">Repeat your new password</label>
               <div class="col-md-6">

--- a/templates/user.html
+++ b/templates/user.html
@@ -17,7 +17,7 @@
               {% if ask_old_password %}
                 <label class="col-md-6 control-label" for="old_password">Old password</label>
                 <div class="col-md-6">
-                    <input id="old_password" name="old_password" type="password" required pattern="\w+" placeholder="" class="form-control input-md">
+                    <input id="old_password" name="old_password" type="password" required pattern=".+" placeholder="" class="form-control input-md">
                 </div>
               {% endif %}
               <label class="col-md-6 control-label" for="new_password">New password</label>

--- a/tests.py
+++ b/tests.py
@@ -55,6 +55,9 @@ class BasicTestCase(unittest.TestCase):
         r = self.client.get("/", environ_base = { "REMOTE_USER": "user42" })
         self.assertEqual(r.status_code, 302)
         self.assertIn("/user/user42", r.location)
+        r = self.client.get("/?return_to=/lala", environ_base = { "REMOTE_USER": "user42" })
+        self.assertEqual(r.status_code, 302)
+        self.assertIn("/user/user42?return_to=/lala", r.location)
 
 
     def test_redirect_after_pwd_change(self):

--- a/tests.py
+++ b/tests.py
@@ -84,6 +84,12 @@ class BasicTestCase(unittest.TestCase):
             r = self.client.post("/user/%s" % user, data = {"old_password": "new123456!", "new_password": "New!123456", "repeat_password":"New!123456"}, environ_base = { "REMOTE_USER": "%s" % user })
             self.assertEqual(r.status_code, 200)
             self.assertIn("Password changed", r.data)
+            r = self.client.post("/user/%s" % user, data = {"old_password": "New!123456", "new_password": "new$!^-99", "repeat_password":"new$!^-99"}, environ_base = { "REMOTE_USER": "%s" % user })
+            self.assertEqual(r.status_code, 200)
+            self.assertIn("Password changed", r.data)
+            r = self.client.post("/user/%s" % user, data = {"old_password": "new$!^-99", "new_password": "$#!^9NEw@&*-", "repeat_password":"$#!^9NEw@&*-"}, environ_base = { "REMOTE_USER": "%s" % user })
+            self.assertEqual(r.status_code, 200)
+            self.assertIn("Password changed", r.data)
 
 
 

--- a/tests.py
+++ b/tests.py
@@ -75,6 +75,12 @@ class BasicTestCase(unittest.TestCase):
             r = self.client.post("/user/%s" % user, data = {"old_password": "New12345", "new_password": "New12345678", "repeat_password":"New12345678"}, environ_base = { "REMOTE_USER": "%s" % user })
             self.assertEqual(r.status_code, 200)
             self.assertIn("Password changed", r.data)
+            r = self.client.post("/user/%s" % user, data = {"old_password": "New12345678", "new_password": "new123456!", "repeat_password":"new123456!"}, environ_base = { "REMOTE_USER": "%s" % user })
+            self.assertEqual(r.status_code, 200)
+            self.assertIn("Password changed", r.data)
+            r = self.client.post("/user/%s" % user, data = {"old_password": "new123456!", "new_password": "New!123456", "repeat_password":"New!123456"}, environ_base = { "REMOTE_USER": "%s" % user })
+            self.assertEqual(r.status_code, 200)
+            self.assertIn("Password changed", r.data)
 
 
 


### PR DESCRIPTION
- Change regex for new password to require an upper case OR a special character from a given list ; fix regex for old password to authorize any characters (special character weren't matched) ; and related tests
- Pass through arguments when redirecting from root directory, and associated test
